### PR TITLE
444 cant find drosophila rhopaloa

### DIFF
--- a/t3_species_glossary.module
+++ b/t3_species_glossary.module
@@ -26,3 +26,25 @@ include_once 't3_species_glossary.features.inc';
       }
     }
   } */
+
+/**
+ * Implements of hook_update_N().
+ */
+function t3_species_glossary_update_7001() {
+  // Load the view by its machine name
+  $view = views_get_view('t3_species_glossary');
+
+  if ($view) {
+    // We have a view, let's get the $handler for it.
+    $handler = &$view->display['default'];
+    if ($handler) {
+      // Add Species to the Sort criterion.
+      $handler->display_options['sorts']['taxrank__species']['id'] = 'taxrank__species';
+      $handler->display_options['sorts']['taxrank__species']['table'] = 'OBI__0100026';
+      $handler->display_options['sorts']['taxrank__species']['field'] = 'taxrank__species';
+    }
+
+    // Save the changes to the view
+    views_save_view($view);
+  }
+}

--- a/t3_species_glossary.views_default.inc
+++ b/t3_species_glossary.views_default.inc
@@ -72,6 +72,10 @@ function t3_species_glossary_views_default_views() {
   $handler->display->display_options['sorts']['taxrank__genus']['table'] = 'OBI__0100026';
   $handler->display->display_options['sorts']['taxrank__genus']['field'] = 'taxrank__genus';
   $handler->display->display_options['sorts']['taxrank__genus']['expose']['label'] = 'Genus';
+  /* Sort criterion: Organism: Species */
+  $handler->display->display_options['sorts']['taxrank__species']['id'] = 'taxrank__species';
+  $handler->display->display_options['sorts']['taxrank__species']['table'] = 'OBI__0100026';
+  $handler->display->display_options['sorts']['taxrank__species']['field'] = 'taxrank__species';
   /* Contextual filter: Global: Null */
   $handler->display->display_options['arguments']['null']['id'] = 'null';
   $handler->display->display_options['arguments']['null']['table'] = 'views';


### PR DESCRIPTION
The original sorting for organisms only sorted on Genus, it now also sorts on genus.
This PR includes code that update currently installed instances of this view, as well as on fresh installs of course.